### PR TITLE
update StartDatastoreSegment

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ RequestWithContextとGetClientと送信(cliend.Do)をまとめて行う
 res, err := apm.RequestDoWithContext(ctx, req)
 ```
 
+## StartDatastoreSegment
+DB(MySQL)のAPM
+
+使用例
+```
+// tx is parent APM transaction
+s := apm.startdatastoresegment(tx, "select * from `categories` where `id` = ?", categoryid)
+err = sqlx.get(q, &category, "select * from `categories` where `id` = ?", categoryid)
+s.End()
+```
+
+使用するにはDB情報を事前にセット(必須ではない)
+```
+apm.SetupDB(host, port, dbname)
+```
+
 ## reference
 
 https://github.com/muroon/isucon9-qualify/commit/9e0d5df64bd747288e1b49c1e680dd56dd75e771#diff-10a40f961254d187b7cb202a0c22bca0

--- a/apm/apm.go
+++ b/apm/apm.go
@@ -4,26 +4,34 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
 	goji "goji.io"
 	"goji.io/pat"
 )
 
-const (
-	DBInsert string = "INSERT"
-	DBSelect string = "SELECT"
-	DBUpdate string = "UPDATE"
-	DBDelete string = "DELETE"
-)
-
 var (
-	app *newrelic.Application
+	app    *newrelic.Application
 	client = &http.Client{
 		Transport: newrelic.NewRoundTripper(nil),
 	}
+	mySQLConnData = mySQLConnectionData{
+		host:   "localhost",
+		port:   "3306",
+		dbName: "isucon",
+	}
 	DefaultClient = http.DefaultClient // TODO: 問題によってはかわる可能性あり
+
 )
+
+type mySQLConnectionData struct {
+	host   string
+	port   string
+	dbName string
+}
 
 // Transaction (NoWeb)トランザクション用
 type Transaction struct {
@@ -62,6 +70,15 @@ func Setup(appName string, license string) (err error) {
 	return err
 }
 
+// SetupDB setup DB info
+func SetupDB(host, port, dbname string) {
+	mySQLConnData = mySQLConnectionData{
+		host:   host,
+		port:   port,
+		dbName: dbname,
+	}
+}
+
 // HandleFunc Web handler 設定
 // TODO:問題によっては引数が変わる
 func HandleFunc(mux *goji.Mux, pattern *pat.Pattern, hdl http.HandlerFunc) {
@@ -92,22 +109,97 @@ func StartTransaction(name string) *Transaction {
 }
 
 // StartDatastoreSegment (NoWeb)Datastore用セグメント開始
-func StartDatastoreSegment(tx *Transaction, sqlType, table, sql string) DatastoreSegment {
+func StartDatastoreSegment(tx *Transaction, query string, params ...interface{}) DatastoreSegment {
 	d := DatastoreSegment{}
 	if tx.txn != nil && isEnable() {
-		d.seg = newrelic.DatastoreSegment{
-			StartTime:          tx.txn.StartSegmentNow(),
-			Product:            newrelic.DatastoreMySQL,
-			Collection:         table,
-			Operation:          sqlType,
-			ParameterizedQuery: sql,
-			QueryParameters:    map[string]interface{}{},
-			Host:               "mysql-server-1",
-			PortPathOrID:       "3306",
-			DatabaseName:       "isucari",
-		}
+		d.seg = createDataStoreSegment(tx, query, params...)
 	}
 	return d
+}
+
+// createDataStoreSegmentで使用する変数
+var (
+	basicTable        = `[^)(\]\[\}\{\s,;]+`
+	enclosedTable     = `[\[\(\{]` + `\s*` + basicTable + `\s*` + `[\]\)\}]`
+	tablePattern      = `(` + `\s+` + basicTable + `|` + `\s*` + enclosedTable + `)`
+	extractTableRegex = regexp.MustCompile(`[\s` + "`" + `"'\(\)\{\}\[\]]*`)
+	updateRegex       = regexp.MustCompile(`(?is)^update(?:\s+(?:low_priority|ignore|or|rollback|abort|replace|fail|only))*` + tablePattern)
+	sqlOperations     = map[string]*regexp.Regexp{
+		"select":   regexp.MustCompile(`(?is)^.*?\sfrom` + tablePattern),
+		"delete":   regexp.MustCompile(`(?is)^.*?\sfrom` + tablePattern),
+		"insert":   regexp.MustCompile(`(?is)^.*?\sinto?` + tablePattern),
+		"update":   updateRegex,
+		"call":     nil,
+		"create":   nil,
+		"drop":     nil,
+		"show":     nil,
+		"set":      nil,
+		"exec":     nil,
+		"execute":  nil,
+		"alter":    nil,
+		"commit":   nil,
+		"rollback": nil,
+	}
+	firstWordRegex   = regexp.MustCompile(`^\w+`)
+	cCommentRegex    = regexp.MustCompile(`(?is)/\*.*?\*/`)
+	lineCommentRegex = regexp.MustCompile(`(?im)(?:--|#).*?$`)
+	sqlPrefixRegex   = regexp.MustCompile(`^[\s;]*`)
+)
+
+//queryはクエリ文。paramsにはクエリのパラメーターを可変長引数で渡す
+func createDataStoreSegment(tx *Transaction, query string, params ...interface{}) newrelic.DatastoreSegment {
+	queryParams := make(map[string]interface{}, len(params))
+	var i = 0
+	for _, param := range params {
+		switch x := param.(type) {
+		case []interface{}:
+			for _, p := range x {
+				queryParams["?_"+strconv.Itoa(i)] = p
+				i++
+			}
+		case interface{}:
+			queryParams["?_"+strconv.Itoa(i)] = x
+			i++
+		default:
+			//ignore
+		}
+	}
+
+	s := cCommentRegex.ReplaceAllString(query, "")
+	s = lineCommentRegex.ReplaceAllString(s, "")
+	s = sqlPrefixRegex.ReplaceAllString(s, "")
+	op := strings.ToLower(firstWordRegex.FindString(s))
+	var operation, collection = "", ""
+	if rg, ok := sqlOperations[op]; ok {
+		operation = op
+		if nil != rg {
+			if m := rg.FindStringSubmatch(s); len(m) > 1 {
+				collection = extractTable(m[1])
+			}
+		}
+	}
+	segment := newrelic.DatastoreSegment{
+		StartTime:          tx.txn.StartSegmentNow(),
+		Product:            newrelic.DatastoreMySQL,
+		Collection:         collection,
+		Operation:          operation,
+		ParameterizedQuery: query,
+		QueryParameters:    queryParams,
+		Host:               mySQLConnData.host,
+		PortPathOrID:       mySQLConnData.port,
+		DatabaseName:       mySQLConnData.dbName,
+	}
+	return segment
+}
+
+//クエリからテーブル名と操作名をパースする処理はAgentのコードから流用
+//the following code is copied from https://github.com/newrelic/go-agent/blob/06c801d5571056abac8ac9dfa07cf12ca869e920/v3/newrelic/sqlparse/sqlparse.go
+func extractTable(s string) string {
+	s = extractTableRegex.ReplaceAllString(s, "")
+	if idx := strings.Index(s, "."); idx > 0 {
+		s = s[idx+1:]
+	}
+	return s
 }
 
 func isEnable() bool {


### PR DESCRIPTION
- DBのAPM Segment開始メソッドのStartDatastoreSegmentを変更する
  - createDataStoreSegmentを導入する
    - StartDatastoreSegmentｎo引数をシンプルがシンプルになる
      - インターフェイスが実DBアクセスに似ているので以前よりは仕込むのが楽になるはず
      ```
      // tx is parent APM transaction
      s := apm.startdatastoresegment(tx, "select * from `categories` where `id` = ?", categoryid)
      err = sqlx.get(q, &category, "select * from `categories` where `id` = ?", categoryid)
      s.End()
      ```
    - クエリのバインドパラメーターがNewRelic上で確認可能になる
      ![new_relic_db_amp](https://user-images.githubusercontent.com/301822/129442502-dccdb44c-ea1f-4159-b5c0-b7b728931663.png)
  - [使用例](https://github.com/muroon/isucon9-qualify/commit/36236670ae1347a6346e8ff904760be0a3fee23d)
