### PR TITLE
GetApp追加、isEnableを公開

### DIFF
--- a/apm/apm.go
+++ b/apm/apm.go
@@ -48,7 +48,7 @@ func Setup(appName string, license string) (err error) {
 // TODO:問題によっては引数が変わる
 func HandleFunc(mux *goji.Mux, pattern *pat.Pattern, hdl http.HandlerFunc) {
 	whdl := hdl
-	if isEnable() {
+	if IsEnable() {
 		_, whdl = newrelic.WrapHandleFunc(app, pattern.String(), hdl)
 	}
 	mux.HandleFunc(pattern, whdl)
@@ -58,7 +58,7 @@ func HandleFunc(mux *goji.Mux, pattern *pat.Pattern, hdl http.HandlerFunc) {
 // TODO:問題によっては引数が変わる
 func Handle(mux *goji.Mux, pattern *pat.Pattern, hdl http.Handler) {
 	whdl := hdl
-	if isEnable() {
+	if IsEnable() {
 		_, whdl = newrelic.WrapHandle(app, pattern.String(), hdl)
 	}
 	mux.Handle(pattern, whdl)
@@ -67,19 +67,19 @@ func Handle(mux *goji.Mux, pattern *pat.Pattern, hdl http.Handler) {
 // StartTransaction (NoWeb)トランザクション開始
 func StartTransaction(name string) *Transaction {
 	st := new(Transaction)
-	if isEnable() {
+	if IsEnable() {
 		st.txn = app.StartTransaction(name)
 	}
 	return st
 }
 
-func isEnable() bool {
+func IsEnable() bool {
 	return app != nil
 }
 
 // MiddlewareNewRelicTransaction to create/end NewRelic transaction
 func MiddlewareNewRelicTransaction(inner http.Handler) http.Handler {
-	if !isEnable() {
+	if !IsEnable() {
 		mw := func(w http.ResponseWriter, r *http.Request) {
 			inner.ServeHTTP(w, r)
 		}
@@ -99,7 +99,7 @@ func MiddlewareNewRelicTransaction(inner http.Handler) http.Handler {
 
 // RequestWithContext RequestにNewRelicのContextをつける
 func RequestWithContext(ctx context.Context, req *http.Request) *http.Request {
-	if !isEnable() {
+	if !IsEnable() {
 		return req
 	}
 	txn := newrelic.FromContext(ctx)
@@ -109,7 +109,7 @@ func RequestWithContext(ctx context.Context, req *http.Request) *http.Request {
 
 // GetClient リクエスト送信クライアントを返す
 func GetClient() *http.Client {
-	if !isEnable() {
+	if !IsEnable() {
 		return DefaultClient
 	}
 

--- a/apm/apm.go
+++ b/apm/apm.go
@@ -2,15 +2,16 @@ package apm
 
 import (
 	"context"
+	"net/http"
+
 	goji "goji.io"
 	"goji.io/pat"
-	"net/http"
 
 	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 var (
-	app *newrelic.Application
+	app    *newrelic.Application
 	client = &http.Client{
 		Transport: newrelic.NewRoundTripper(nil),
 	}
@@ -119,4 +120,8 @@ func GetClient() *http.Client {
 func RequestDoWithContext(ctx context.Context, req *http.Request) (*http.Response, error) {
 	req = RequestWithContext(ctx, req)
 	return GetClient().Do(req)
+}
+
+func GetApp() *newrelic.Application {
+	return app
 }

--- a/apm/db.go
+++ b/apm/db.go
@@ -1,10 +1,11 @@
 package apm
 
 import (
-	"github.com/newrelic/go-agent/v3/newrelic"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/newrelic/go-agent/v3/newrelic"
 )
 
 // SetupDB setup DB info
@@ -22,7 +23,7 @@ type DatastoreSegment struct {
 }
 
 func (d DatastoreSegment) End() {
-	if isEnable() {
+	if IsEnable() {
 		d.seg.End()
 	}
 }
@@ -30,7 +31,7 @@ func (d DatastoreSegment) End() {
 // StartDatastoreSegment (NoWeb)Datastore用セグメント開始
 func StartDatastoreSegment(tx *Transaction, query string, params ...interface{}) DatastoreSegment {
 	d := DatastoreSegment{}
-	if tx.txn != nil && isEnable() {
+	if tx.txn != nil && IsEnable() {
 		d.seg = createDataStoreSegment(tx, query, params...)
 	}
 	return d

--- a/apm/echo.go
+++ b/apm/echo.go
@@ -6,17 +6,17 @@ import (
 )
 
 // MiddlewareNewRelicEcho echo middleware
-func MiddlewareNewRelicEcho(e *echo.Echo)  {
-	if isEnable() {
+func MiddlewareNewRelicEcho(e *echo.Echo) {
+	if IsEnable() {
 		e.Use(nrecho.Middleware(app))
 	}
 }
 
 // TransactionFromEchoContext get Transaction from echo.Context
-func TransactionFromEchoContext(c echo.Context) *Transaction{
+func TransactionFromEchoContext(c echo.Context) *Transaction {
 	st := new(Transaction)
-	if isEnable() {
-		st.txn =  nrecho.FromContext(c)
+	if IsEnable() {
+		st.txn = nrecho.FromContext(c)
 	}
 	return st
 }


### PR DESCRIPTION
echo v4だと型が合わずに `apm/echo.go`の処理が使えなかった、、

```
cannot use srv (type *"github.com/labstack/echo/v4".Echo) as type *"github.com/labstack/echo".Echo in argument to apm.MiddlewareNewRelicEcho
```

インターフェースが合わなかった場合でも同じ処理をmainパッケージ内で自前で実装できるように必要な処理を追加
